### PR TITLE
Add configurable nodeSelectors to Fluid core workloads

### DIFF
--- a/charts/fluid/templates/controller/alluxioruntime_controller.yaml
+++ b/charts/fluid/templates/controller/alluxioruntime_controller.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
       serviceAccountName: alluxioruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.runtime.alluxio.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.runtime.alluxio.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.runtime.alluxio.tolerations }}
       tolerations:
 {{ toYaml .Values.runtime.alluxio.tolerations | indent 6}}

--- a/charts/fluid/templates/controller/dataset_controller.yaml
+++ b/charts/fluid/templates/controller/dataset_controller.yaml
@@ -28,6 +28,10 @@ spec:
       {{- end }}
       serviceAccountName: dataset-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.dataset.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.dataset.nodeSelector | indent 8}}
+      {{- end }}
       {{- if .Values.dataset.tolerations }}
       tolerations:
 {{ toYaml .Values.dataset.tolerations | indent 6}}

--- a/charts/fluid/templates/controller/efcruntime_controller.yaml
+++ b/charts/fluid/templates/controller/efcruntime_controller.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
       serviceAccountName: efcruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.runtime.efc.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.runtime.efc.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.runtime.efc.tolerations }}
       tolerations:
 {{ toYaml .Values.runtime.efc.tolerations | indent 6 }}

--- a/charts/fluid/templates/controller/fluidapp_controller.yaml
+++ b/charts/fluid/templates/controller/fluidapp_controller.yaml
@@ -26,6 +26,10 @@ spec:
       {{- end }}
       serviceAccountName: fluidapp-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.fluidapp.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.fluidapp.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.fluidapp.tolerations }}
       tolerations:
 {{ toYaml .Values.fluidapp.tolerations | indent 6 }}

--- a/charts/fluid/templates/controller/goosefsruntime_controller.yaml
+++ b/charts/fluid/templates/controller/goosefsruntime_controller.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
       serviceAccountName: goosefsruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.runtime.goosefs.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.runtime.goosefs.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.runtime.goosefs.tolerations }}
       tolerations:
 {{ toYaml .Values.runtime.goosefs.tolerations | indent 6 }}

--- a/charts/fluid/templates/controller/jindoruntime_controller.yaml
+++ b/charts/fluid/templates/controller/jindoruntime_controller.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
       serviceAccountName: jindoruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.runtime.jindo.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.runtime.jindo.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.runtime.jindo.tolerations }}
       tolerations:
 {{ toYaml .Values.runtime.jindo.tolerations | indent 6 }}

--- a/charts/fluid/templates/controller/juicefsruntime_controller.yaml
+++ b/charts/fluid/templates/controller/juicefsruntime_controller.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
       serviceAccountName: juicefsruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.runtime.juicefs.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.runtime.juicefs.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.runtime.juicefs.tolerations }}
       tolerations:
 {{ toYaml .Values.runtime.juicefs.tolerations | indent 6 }}

--- a/charts/fluid/templates/controller/thinruntime_controller.yaml
+++ b/charts/fluid/templates/controller/thinruntime_controller.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
       serviceAccountName: thinruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.runtime.thin.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.runtime.thin.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.runtime.thin.tolerations }}
       tolerations:
 {{ toYaml .Values.runtime.thin.tolerations | indent 6 }}

--- a/charts/fluid/templates/controller/vineyardruntime_controller.yaml
+++ b/charts/fluid/templates/controller/vineyardruntime_controller.yaml
@@ -30,6 +30,10 @@ spec:
       {{- end }}
       serviceAccountName: vineyardruntime-controller
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.runtime.vineyard.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.runtime.vineyard.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.runtime.vineyard.tolerations }}
       tolerations:
 {{ toYaml .Values.runtime.vineyard.tolerations | indent 6 }}

--- a/charts/fluid/templates/csi/daemonset.yaml
+++ b/charts/fluid/templates/csi/daemonset.yaml
@@ -20,6 +20,10 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       serviceAccountName: fluid-csi
+      {{- if .Values.csi.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.csi.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.csi.tolerations }}
       tolerations:
 {{ toYaml .Values.csi.tolerations | indent 6 }}

--- a/charts/fluid/templates/upgrade/crd-upgrade.yaml
+++ b/charts/fluid/templates/upgrade/crd-upgrade.yaml
@@ -19,6 +19,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.crdUpgrade.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.crdUpgrade.nodeSelector | indent 8 }}
+      {{- end }}
       {{- if .Values.crdUpgrade.tolerations }}
       tolerations:
 {{ toYaml .Values.crdUpgrade.tolerations | indent 6 }}

--- a/charts/fluid/templates/webhook/webhook.yaml
+++ b/charts/fluid/templates/webhook/webhook.yaml
@@ -26,6 +26,10 @@ spec:
       {{- end }}
       serviceAccountName: fluid-webhook
       {{ include "fluid.controlplane.affinity" . | nindent 6}}
+      {{- if .Values.webhook.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.webhook.nodeSelector | indent 8}}
+      {{- end }}
       containers:
       - image: {{ include "fluid.controlplane.imageTransform" (list .Values.webhook.imagePrefix .Values.webhook.imageName .Values.webhook.imageTag . ) }}
         imagePullPolicy: IfNotPresent

--- a/charts/fluid/values.yaml
+++ b/charts/fluid/values.yaml
@@ -20,6 +20,8 @@ crdUpgrade:
   enabled: true
   tolerations:
     - operator: Exists
+  nodeSelector:
+    kubernetes.io/os: linux
   # This sets the time-to-live (TTL) for crd-upgrade jobs. Default is 259200 seconds (3 days).
   ttlSecondsAfterFinished: 259200 
   imagePrefix: *defaultImagePrefix
@@ -33,6 +35,8 @@ dataset:
   replicas: 1
   tolerations:
     - operator: Exists
+  nodeSelector:
+    kubernetes.io/os: linux
   resources: ~
   # resources:
   #   requests:
@@ -55,6 +59,8 @@ csi:
   enabled: true
   tolerations:
     - operator: Exists
+  nodeSelector:
+    kubernetes.io/os: linux
   featureGates: "FuseRecovery=false"
   config:
     hostNetwork: false
@@ -93,6 +99,8 @@ runtime:
     env: []
     tolerations:
       - operator: Exists
+    nodeSelector:
+      kubernetes.io/os: linux
     resources: ~
     # resources:
     #   requests:
@@ -131,6 +139,8 @@ runtime:
     env: []
     tolerations:
       - operator: Exists
+    nodeSelector:
+      kubernetes.io/os: linux
     resources: ~
     # resources:
     #   requests:
@@ -172,6 +182,8 @@ runtime:
     env: []
     tolerations:
       - operator: Exists
+    nodeSelector:
+      kubernetes.io/os: linux
     resources: ~
     # resources:
     #   requests:
@@ -209,6 +221,8 @@ runtime:
     env: []
     tolerations:
       - operator: Exists
+    nodeSelector:
+      kubernetes.io/os: linux
     resources: ~
     # resources:
     #   requests:
@@ -240,6 +254,8 @@ runtime:
     syncRetryRateLimitDuration: 0s
     tolerations:
       - operator: Exists
+    nodeSelector:
+      kubernetes.io/os: linux
     resources: ~
     # resources:
     #   requests:
@@ -265,6 +281,8 @@ runtime:
     env: []
     tolerations:
       - operator: Exists
+    nodeSelector:
+      kubernetes.io/os: linux
     resources: ~
     # resources:
     #   requests:
@@ -305,6 +323,8 @@ runtime:
     portRange: 32000-34000
     tolerations:
       - operator: Exists
+    nodeSelector:
+      kubernetes.io/os: linux
     resources: ~
     # resources:
     #   requests:
@@ -346,6 +366,8 @@ webhook:
   reinvocationPolicy: IfNeeded
   tolerations:
     - operator: Exists
+  nodeSelector:
+    kubernetes.io/os: linux
   resources: ~
   # resources:
   #   requests:
@@ -414,6 +436,8 @@ fluidapp:
   replicas: 1
   tolerations:
     - operator: Exists
+  nodeSelector:
+    kubernetes.io/os: linux
   resources: ~
   # resources:
   #   requests:


### PR DESCRIPTION
## Summary
- Add default `kubernetes.io/os: linux` nodeSelectors for all core Fluid workloads (controllers, dataset, runtime controllers, CSI daemonset, webhook, CRD upgrade job) in values.
- Wire nodeSelector blocks into every relevant pod template so users can override or extend scheduling constraints.
- Keep existing tolerations and affinity behavior unchanged.

## Changes
- `values.yaml`: new `nodeSelector` defaults for dataset, CSI, webhook, fluidapp, CRD upgrader, and each runtime controller (alluxio, jindo, goosefs, juicefs, thin, efc, vineyard).
- Templates: inject nodeSelector into controller Deployments, CSI DaemonSet, webhook Deployment, and CRD upgrade Job.

## Testing
- `helm template charts/fluid` (manual) to confirm each rendered pod includes the nodeSelector stanza.

## Notes for reviewers
- Defaults are minimal and match Kubernetes’ standard label; users can override per component via `values.yaml`.
- No behavior change for clusters already scheduling on Linux; adds explicit scheduling hook for constrained clusters.

## Checklist
- [x] Changes limited to Helm values/templates for scheduling.
- [x] Tested with `helm template`.
- [x] Commit includes `Signed-off-by`.

## Branch
`feature/add-node-selector`

## How to override (example)
```yaml
dataset:
  nodeSelector:
    kubernetes.io/os: linux
    my.custom/zone: az1
```